### PR TITLE
Fix Y positioning bug

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -54,8 +54,8 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'
     implementation 'androidx.navigation:navigation-ui-ktx:2.4.1'
 
-    implementation 'com.github.kcrimi:ToolTipDialog:~1.1.4' // import from jitpack
-//    implementation project(":tooltipdialog") // Local import for development purposes
+//    implementation 'com.github.kcrimi:ToolTipDialog:1.1.4+' // import from jitpack
+    implementation project(":tooltipdialog") // Local import for development purposes
 
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -12,10 +12,10 @@
         <activity
             android:name="com.kcrimi.sample.SampleActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/sample/src/main/java/com/kcrimi/sample/SampleActivity.kt
+++ b/sample/src/main/java/com/kcrimi/sample/SampleActivity.kt
@@ -110,7 +110,6 @@ class SampleActivity : AppCompatActivity() {
                 .title("You can point to any of your views on screen just like this FAB")
                 .pointTo(location[0] + it.width / 2, location[1] - it.height)
                 .setToolTipListener(toolTipListener)
-
             if (shadeToggle.isChecked) {
                 dialog.addPeekThroughView(it)
             }

--- a/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ScreenUtils.kt
+++ b/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ScreenUtils.kt
@@ -38,7 +38,7 @@ internal object ScreenUtils {
         }
     }
 
-    fun getCutoutHeight(context: Context): Int {
+    fun getTopCutoutHeight(context: Context): Int {
         val wm =
             context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -47,7 +47,17 @@ internal object ScreenUtils {
         } else {
             0
         }
+    }
 
+    fun getBottomCutoutHeight(context: Context): Int {
+        val wm =
+            context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val inset = wm.currentWindowMetrics.windowInsets.getInsets(WindowInsets.Type.tappableElement())
+            inset.bottom
+        } else {
+            0
+        }
     }
 
     fun bitmapFromView(view: View): Bitmap {

--- a/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ScreenUtils.kt
+++ b/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ScreenUtils.kt
@@ -4,8 +4,13 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Point
+import android.graphics.Rect
+import android.os.Build
 import android.view.View
+import android.view.WindowInsets
 import android.view.WindowManager
+import android.view.WindowMetrics
+
 
 /**
  * Copyright (c) $today.year.
@@ -22,9 +27,27 @@ internal object ScreenUtils {
     fun getScreenHeight(context: Context): Int {
         val wm =
             context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-        val size = Point()
-        wm.defaultDisplay.getSize(size)
-        return size.y
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+            val windowMetrics = wm.currentWindowMetrics
+            windowMetrics.bounds.height()
+        } else {
+            val size = Point()
+            val display = wm.defaultDisplay
+            display.getSize(size)
+            size.y
+        }
+    }
+
+    fun getCutoutHeight(context: Context): Int {
+        val wm =
+            context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val inset = wm.currentWindowMetrics.windowInsets.getInsets(WindowInsets.Type.tappableElement())
+            inset.top
+        } else {
+            0
+        }
+
     }
 
     fun bitmapFromView(view: View): Bitmap {

--- a/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ToolTipDialog.kt
+++ b/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ToolTipDialog.kt
@@ -81,7 +81,7 @@ class ToolTipDialog(
         windowWidth = usableView.width
 
         statusBarHeight = screenUtils.getScreenHeight(context) - windowHeight
-        val cutoutOffset = screenUtils.getCutoutHeight(context)
+        val cutoutOffset = screenUtils.getTopCutoutHeight(context)
         if (cutoutOffset > 0) {
             statusBarHeight -= (statusBarHeight - cutoutOffset)
         }
@@ -151,7 +151,8 @@ class ToolTipDialog(
         if (position == Position.ABOVE || (position == Position.AUTO && y > windowHeight / 2 - statusBarHeight)) {
             // point is on the lower half of the screen, position dialog above
             params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-            params.bottomMargin = windowHeight - y - statusBarHeight
+            val cutoutOffset = screenUtils.getTopCutoutHeight(context) - screenUtils.getBottomCutoutHeight(context)
+            params.bottomMargin = windowHeight - y - statusBarHeight + cutoutOffset
             if (x >= 0) {
                 pointArrowTo(downArrow, x)
             }

--- a/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ToolTipDialog.kt
+++ b/tooltipdialog/src/main/java/com/kcrimi/tooltipdialog/ToolTipDialog.kt
@@ -79,7 +79,14 @@ class ToolTipDialog(
         val usableView = parentActivity.window.findViewById<View>(Window.ID_ANDROID_CONTENT)
         windowHeight = usableView.height
         windowWidth = usableView.width
+
         statusBarHeight = screenUtils.getScreenHeight(context) - windowHeight
+        val cutoutOffset = screenUtils.getCutoutHeight(context)
+        if (cutoutOffset > 0) {
+            statusBarHeight -= (statusBarHeight - cutoutOffset)
+        }
+
+
 
         // Make Dialog window span the entire screen
         window?.setLayout(WindowManager.LayoutParams.MATCH_PARENT,
@@ -105,7 +112,7 @@ class ToolTipDialog(
         peekThroughViews.forEach {
             val viewBitmap = screenUtils.bitmapFromView(it)
             val xy = IntArray(2)
-            it.getLocationOnScreen(xy)
+            it.getLocationInWindow(xy)
 
             canvas.drawBitmap(viewBitmap,
                 Rect(0, 0, it.measuredWidth, it.measuredHeight),


### PR DESCRIPTION
Addressing Issue: https://github.com/kcrimi/ToolTipDialog/issues/17

Previously, Y positioning of peekthrough views and pointer dialogs were broken on phones with camera notches. This addresses the issue